### PR TITLE
Add 4 and 8 bit bitmap support, add invert parameters, VariPass example, fixes

### DIFF
--- a/Inkplate.cpp
+++ b/Inkplate.cpp
@@ -856,13 +856,13 @@ int Inkplate::drawMonochromeBitmapSd(SdFile *f, struct bitmapHeader bmpHeader, i
     for (i = 0; i < w; i++) {
       uint32_t pixelRow = f->read() << 24 | f->read() << 16 | f->read() << 8 | f->read();
       for (int n = 0; n < 32; n++) {
-        drawPixel((i * 32) + n + x, h - j + y, !(pixelRow & (1ULL << (31 - n))));
+        drawPixel((i * 32) + n + x, h - 1 - j + y, !(pixelRow & (1ULL << (31 - n))));
       }
     }
     if (paddingBits) {
       uint32_t pixelRow = f->read() << 24 | f->read() << 16 | f->read() << 8 | f->read();
       for (int n = 0; n < paddingBits; n++) {
-        drawPixel((i * 32) + n + x, h - j + y, !(pixelRow & (1ULL << (31 - n))));
+        drawPixel((i * 32) + n + x, h - 1 - j + y, !(pixelRow & (1ULL << (31 - n))));
       }
     }
   }
@@ -886,7 +886,7 @@ int Inkplate::drawGrayscaleBitmap24Sd(SdFile *f, struct bitmapHeader bmpHeader, 
       //So then, we are convertng it to grayscale using good old average and gamma correction (from LUT). With this metod, it is still slow (full size image takes 4 seconds), but much beter than prev mentioned method.
       uint8_t px = (f->read() * 2126 / 10000) + (f->read() * 7152 / 10000) + (f->read() * 722 / 10000);
       //drawPixel(i + x, h - j + y, gammaLUT[px]);
-	  drawPixel(i + x, h - j + y, px>>5);
+	  drawPixel(i + x, h - 1 - j + y, px>>5);
 	  //drawPixel(i + x, h - j + y, px/32);
     }
     if (padding) {
@@ -931,7 +931,7 @@ int Inkplate::drawMonochromeBitmapWeb(WiFiClient *s, struct bitmapHeader bmpHead
       if (invert)
         pixelRow = ~pixelRow;
       for (int n = 0; n < 32; n++) {
-        drawPixel((i * 32) + n + x, h - j + y, !(pixelRow & (1ULL << (31 - n))));
+        drawPixel((i * 32) + n + x, h - 1 - j + y, !(pixelRow & (1ULL << (31 - n))));
       }
     }
     if (paddingBits) {
@@ -943,7 +943,7 @@ int Inkplate::drawMonochromeBitmapWeb(WiFiClient *s, struct bitmapHeader bmpHead
       if (invert)
         pixelRow = ~pixelRow;
       for (int n = 0; n < paddingBits; n++) {
-        drawPixel((i * 32) + n + x, h - j + y, !(pixelRow & (1ULL << (31 - n))));
+        drawPixel((i * 32) + n + x, h - 1 - j + y, !(pixelRow & (1ULL << (31 - n))));
       }
     }
   }
@@ -992,7 +992,7 @@ int Inkplate::drawGrayscaleBitmap24Web(WiFiClient *s, struct bitmapHeader bmpHea
       //So then, we are convertng it to grayscale using good old average and gamma correction (from LUT). With this metod, it is still slow (full size image takes 4 seconds), but much beter than prev mentioned method.
       uint8_t px = (r * 2126 / 10000) + (g * 7152 / 10000) + (b * 722 / 10000);
       //drawPixel(i + x, h - j + y, gammaLUT[px]);
-    drawPixel(i + x, h - j + y, px>>5);
+    drawPixel(i + x, h - 1 - j + y, px>>5);
     //drawPixel(i + x, h - j + y, px/32);
     }
     if (padding) {

--- a/Inkplate.h
+++ b/Inkplate.h
@@ -169,6 +169,8 @@ class Inkplate : public Adafruit_GFX {
 	void readBmpHeaderSd(SdFile *_f, struct bitmapHeader *_h);
     void readBmpHeaderWeb(WiFiClient *_s, struct bitmapHeader *_h);
 	int drawMonochromeBitmapSd(SdFile *f, struct bitmapHeader bmpHeader, int x, int y, bool invert);
+    int drawGrayscaleBitmap4Sd(SdFile *f, struct bitmapHeader bmpHeader, int x, int y, bool invert);
+    int drawGrayscaleBitmap8Sd(SdFile *f, struct bitmapHeader bmpHeader, int x, int y, bool invert);
 	int drawGrayscaleBitmap24Sd(SdFile *f, struct bitmapHeader bmpHeader, int x, int y, bool invert);
     int drawMonochromeBitmapWeb(WiFiClient *s, struct bitmapHeader bmpHeader, int x, int y, int len, bool invert);
     int drawGrayscaleBitmap4Web(WiFiClient *s, struct bitmapHeader bmpHeader, int x, int y, int len, bool invert);

--- a/Inkplate.h
+++ b/Inkplate.h
@@ -171,6 +171,8 @@ class Inkplate : public Adafruit_GFX {
 	int drawMonochromeBitmapSd(SdFile *f, struct bitmapHeader bmpHeader, int x, int y, bool invert);
 	int drawGrayscaleBitmap24Sd(SdFile *f, struct bitmapHeader bmpHeader, int x, int y, bool invert);
     int drawMonochromeBitmapWeb(WiFiClient *s, struct bitmapHeader bmpHeader, int x, int y, int len, bool invert);
+    int drawGrayscaleBitmap4Web(WiFiClient *s, struct bitmapHeader bmpHeader, int x, int y, int len, bool invert);
+    int drawGrayscaleBitmap8Web(WiFiClient *s, struct bitmapHeader bmpHeader, int x, int y, int len, bool invert);
     int drawGrayscaleBitmap24Web(WiFiClient *s, struct bitmapHeader bmpHeader, int x, int y, int len, bool invert);
 	void precalculateGamma(uint8_t* c, float gamma);
 };

--- a/Inkplate.h
+++ b/Inkplate.h
@@ -131,8 +131,8 @@ class Inkplate : public Adafruit_GFX {
     void einkOn(void);
     void selectDisplayMode(uint8_t _mode);
 	uint8_t getDisplayMode();
-	int drawBitmapFromSD(SdFile* p, int x, int y);
-	int drawBitmapFromSD(char* fileName, int x, int y);
+	int drawBitmapFromSD(SdFile* p, int x, int y, bool invert = false);
+	int drawBitmapFromSD(char* fileName, int x, int y, bool invert = false);
     int drawBitmapFromWeb(WiFiClient* s, int x, int y, int len, bool invert = false);
     int drawBitmapFromWeb(char* url, int x, int y, bool invert = false);
 	int sdCardInit();
@@ -168,8 +168,8 @@ class Inkplate : public Adafruit_GFX {
 	uint16_t read16(uint8_t* c);
 	void readBmpHeaderSd(SdFile *_f, struct bitmapHeader *_h);
     void readBmpHeaderWeb(WiFiClient *_s, struct bitmapHeader *_h);
-	int drawMonochromeBitmapSd(SdFile *f, struct bitmapHeader bmpHeader, int x, int y);
-	int drawGrayscaleBitmap24Sd(SdFile *f, struct bitmapHeader bmpHeader, int x, int y);
+	int drawMonochromeBitmapSd(SdFile *f, struct bitmapHeader bmpHeader, int x, int y, bool invert);
+	int drawGrayscaleBitmap24Sd(SdFile *f, struct bitmapHeader bmpHeader, int x, int y, bool invert);
     int drawMonochromeBitmapWeb(WiFiClient *s, struct bitmapHeader bmpHeader, int x, int y, int len, bool invert);
     int drawGrayscaleBitmap24Web(WiFiClient *s, struct bitmapHeader bmpHeader, int x, int y, int len, bool invert);
 	void precalculateGamma(uint8_t* c, float gamma);

--- a/examples/2. Advanced Inkplate Features/10-Inkplate_Download_And_Show/10-Inkplate_Download_And_Show.ino
+++ b/examples/2. Advanced Inkplate Features/10-Inkplate_Download_And_Show/10-Inkplate_Download_And_Show.ino
@@ -24,7 +24,6 @@
 #include "HTTPClient.h"             //Include library for HTTPClient
 #include "WiFi.h"                   //Include library for WiFi
 Inkplate display(INKPLATE_1BIT);    //Create an object on Inkplate library and also set library into 1 Bit mode (Monochrome)
-SdFile file;                        //Create SdFile object used for accessing files on SD card
 
 const char* ssid     = "YourWiFiSSID"; //Your WiFi SSID
 const char* password = "YourPass";     //Your WiFi password
@@ -68,7 +67,7 @@ void setup() {
   //Set parameters to speed up the download process.
   http.getStream().setNoDelay(true);
   http.getStream().setTimeout(1);
-  
+
   //Photo taken by: Roberto Fernandez
   http.begin("https://varipass.org/neowise.bmp");
 

--- a/examples/2. Advanced Inkplate Features/10-Inkplate_Download_And_Show/10-Inkplate_Download_And_Show.ino
+++ b/examples/2. Advanced Inkplate Features/10-Inkplate_Download_And_Show/10-Inkplate_Download_And_Show.ino
@@ -49,7 +49,9 @@ void setup() {
 
   //Draw the first image from web.
   //Monochromatic bitmap with 1 bit depth. Images like this load quickest.
-  //The parameter set to true at the end may be used to swap the black and white channels.
+  //NOTE: Both drawBitmapFromWeb methods allow for an optional fourth "invert" parameter. Setting this parameter to true
+  //will flip all colors on the image, making black white and white black. This may be necessary when exporting bitmaps from
+  //certain softwares.
   //Photo taken by: Roberto Fernandez
   if(!display.drawBitmapFromWeb("https://varipass.org/neowise_mono.bmp", 0, 0, true)) {
     //If is something failed (wrong filename or wrong bitmap format), write error message on the screen.

--- a/examples/2. Advanced Inkplate Features/10-Inkplate_Download_And_Show/10-Inkplate_Download_And_Show.ino
+++ b/examples/2. Advanced Inkplate Features/10-Inkplate_Download_And_Show/10-Inkplate_Download_And_Show.ino
@@ -1,18 +1,14 @@
 /*
    10_Inkplate_Download_And_Show example for e-radionica Inkplate6
-   For this example you will need a micro USB cable, Inkplate6, an SD card and an
-   available WiFi connection.
+   For this example you will need a micro USB cable, Inkplate6, and an available WiFi connection.
    Select "Inkplate 6(ESP32)" from Tools -> Board menu.
    Don't have "Inkplate 6(ESP32)" option? Follow our tutorial and add it: 
    https://e-radionica.com/en/blog/add-inkplate-6-to-arduino-ide/
-
-   To work with SD card on Inkplate, you will need to add one extra library.
-   Download and install it from here: https://github.com/e-radionicacom/Inkplate-6-SDFat-Arduino-Library
    
-   You can open .bmp files that have color depth of 1 bit (monochrome bitmap) and 
+   You can open .bmp files that have color depth of 1 bit (monochrome bitmap), 4 bit, 8 bit and 
    24 bit AND have resoluton smaller than 800x600 or otherwise it won't fit on screen.
 
-   This example will show you how you can download a .bmp file (picture) from the web to the SD card and 
+   This example will show you how you can download a .bmp file (picture) from the web and 
    display that image on e-paper display.
 
    Want to learn more about Inkplate? Visit www.inkplate.io

--- a/examples/2. Advanced Inkplate Features/10-Inkplate_Download_And_Show/10-Inkplate_Download_And_Show.ino
+++ b/examples/2. Advanced Inkplate Features/10-Inkplate_Download_And_Show/10-Inkplate_Download_And_Show.ino
@@ -51,7 +51,7 @@ void setup() {
   //Photo taken by: Roberto Fernandez
   if(!display.drawBitmapFromWeb("https://varipass.org/neowise_mono.bmp", 0, 0, true)) {
     //If is something failed (wrong filename or wrong bitmap format), write error message on the screen.
-    //REMEMBER! You can only use Windows Bitmap file with color depth of 1 or 24 bits with no compression! 
+    //REMEMBER! You can only use Windows Bitmap file with color depth of 1, 4, 8 or 24 bits with no compression! 
     display.println("Image open error");
     display.display();
   }
@@ -75,7 +75,7 @@ void setup() {
     if (len > 0) {
       if(!display.drawBitmapFromWeb(http.getStreamPtr(), 0, 0, len)) {
         //If is something failed (wrong filename or wrong bitmap format), write error message on the screen.
-        //REMEMBER! You can only use Windows Bitmap file with color depth of 1 or 24 bits with no compression! 
+        //REMEMBER! You can only use Windows Bitmap file with color depth of 1, 4, 8 or 24 bits with no compression! 
         display.println("Image open error");
         display.display();
       }

--- a/examples/2. Advanced Inkplate Features/5-Inkplate_SD_BMP_pictures/5-Inkplate_SD_BMP_pictures.ino
+++ b/examples/2. Advanced Inkplate Features/5-Inkplate_SD_BMP_pictures/5-Inkplate_SD_BMP_pictures.ino
@@ -36,6 +36,9 @@ void setup() {
     display.partialUpdate();
 
     //If card is properly init, try to load image and display it on e-paper at position X=0, Y=0
+    //NOTE: Both drawBitmapFromSD methods allow for an optional fourth "invert" parameter. Setting this parameter to true
+    //will flip all colors on the image, making black white and white black. This may be necessary when exporting bitmaps from
+    //certain softwares.
     if(!display.drawBitmapFromSD("image1.bmp", 0, 0)) {
       //If is something failed (wrong filename or wrong bitmap format), write error message on the screen.
       //REMEMBER! You can only use Windows Bitmap file with color depth of 1 or 24 bits with no compression! 

--- a/examples/2. Advanced Inkplate Features/5-Inkplate_SD_BMP_pictures/5-Inkplate_SD_BMP_pictures.ino
+++ b/examples/2. Advanced Inkplate Features/5-Inkplate_SD_BMP_pictures/5-Inkplate_SD_BMP_pictures.ino
@@ -9,7 +9,7 @@
    To work with SD card on Inkplate, you will need to add one extra library.
    Download and install it from here: https://github.com/e-radionicacom/Inkplate-6-SDFat-Arduino-Library
    
-   You can open .bmp files that have color depth of 1 bit (monochrome bitmap) and 
+   You can open .bmp files that have color depth of 1 bit (monochrome bitmap), 4 bit, 8 bit and 
    24 bit AND have resoluton smaller than 800x600 or otherwise it won't fit on screen.
 
    This example will show you how you can read .bmp files (pictures) from SD card and 

--- a/examples/2. Advanced Inkplate Features/5-Inkplate_SD_BMP_pictures/5-Inkplate_SD_BMP_pictures.ino
+++ b/examples/2. Advanced Inkplate Features/5-Inkplate_SD_BMP_pictures/5-Inkplate_SD_BMP_pictures.ino
@@ -41,7 +41,7 @@ void setup() {
     //certain softwares.
     if(!display.drawBitmapFromSD("image1.bmp", 0, 0)) {
       //If is something failed (wrong filename or wrong bitmap format), write error message on the screen.
-      //REMEMBER! You can only use Windows Bitmap file with color depth of 1 or 24 bits with no compression! 
+      //REMEMBER! You can only use Windows Bitmap file with color depth of 1, 4, 8 or 24 bits with no compression! 
       display.println("Image open error");
       display.display();
     }

--- a/examples/3. Others/3-Inkplate_VariPass_Graphs/3-Inkplate_VariPass_Graphs.ino
+++ b/examples/3. Others/3-Inkplate_VariPass_Graphs/3-Inkplate_VariPass_Graphs.ino
@@ -60,8 +60,6 @@ void setup() {
   //  eink   - Should be set to true to generate a monochrome 1 bit bitmap better suitable for Inkplate.
   // For more detailed explanation and more parameters, please visit the docs page: https://varipass.org/docs/ 
   if(!display.drawBitmapFromWeb("https://api.varipass.org/?action=sgraph&id=kbg3eQfA&width=400&height=300&eink=true", 200, 150)) {
-    //If is something failed (wrong filename or wrong bitmap format), write error message on the screen.
-    //REMEMBER! You can only use Windows Bitmap file with color depth of 1 or 24 bits with no compression! 
     display.println("Image open error");
     display.partialUpdate();
   }

--- a/examples/3. Others/3-Inkplate_VariPass_Graphs/3-Inkplate_VariPass_Graphs.ino
+++ b/examples/3. Others/3-Inkplate_VariPass_Graphs/3-Inkplate_VariPass_Graphs.ino
@@ -1,0 +1,75 @@
+/*
+   3-Inkplate_VariPass_Graphs example for e-radionica Inkplate6
+   For this example you will need a micro USB cable, Inkplate6, and an available WiFi connection.
+   Select "Inkplate 6(ESP32)" from Tools -> Board menu.
+   Don't have "Inkplate 6(ESP32)" option? Follow our tutorial and add it: 
+   https://e-radionica.com/en/blog/add-inkplate-6-to-arduino-ide/
+
+   This example will show you how you can use the API on the VariPass website to download and display
+   a sensor graph on the e-paper display.
+
+   VariPass is a website which allows you to host various online "variables" which you can write to
+   and read from using the VariPass API. This allows you to store sensor logs and later retrieve them
+   for graphing, analysis, etc.
+   This example uses an already public variable as an example. The graph is fed every minute with data
+   from Thorinair's (https://github.com/Thorinair/) geiger counter, so each startup of the Inkplate will
+   display updated values.
+
+   To learn more about VariPass and how you can use it for your own projects, please visit: https://varipass.org/
+   If you want to easily integrate the read/write functionality in your project, use the official library:
+   https://github.com/Thorinair/VariPass-for-ESP8266-ESP32
+
+   Want to learn more about Inkplate? Visit www.inkplate.io
+   Looking to get support? Write on our forums: http://forum.e-radionica.com/en/
+   23 July 2020 by e-radionica.com
+*/
+
+#include "Inkplate.h"               //Include Inkplate library to the sketch
+#include "WiFi.h"                   //Include library for WiFi
+Inkplate display(INKPLATE_1BIT);    //Create an object on Inkplate library and also set library into 1 Bit mode (Monochrome)
+
+const char* ssid     = "YourWiFiSSID"; //Your WiFi SSID
+const char* password = "YourPass";     //Your WiFi password
+
+void setup() {
+  display.begin();        //Init Inkplate library (you should call this function ONLY ONCE)
+  display.clearDisplay(); //Clear frame buffer of display
+  display.display();      //Put clear image on display
+
+  display.print("Connecting to WiFi...");
+  display.partialUpdate();
+
+  //Connect to the WiFi network.
+  WiFi.mode(WIFI_MODE_STA);
+  WiFi.begin(ssid, password);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    display.print(".");
+    display.partialUpdate();
+  }
+  display.println("\nWiFi OK! Downloading...");
+  display.partialUpdate();
+
+  //Use a HTTP get request to fetch the graph from VariPass.
+  //The API expects a few parameters in the URL to allow it to work.
+  //  action - Should be set to "sgraph" or "graph" in order to generate a compatible image.
+  //  id     - ID of the variable. It is enough to specify just the ID if the variable is public,
+  //           but a "key" parameter should also be specified if not.
+  //  width  - Width of the generated graph, here set to half the Inkplate's width.
+  //  height - Height of the generated graph, here set to half the Inkplate's height.
+  //  eink   - Should be set to true to generate a monochrome 1 bit bitmap better suitable for Inkplate.
+  // For more detailed explanation and more parameters, please visit the docs page: https://varipass.org/docs/ 
+  if(!display.drawBitmapFromWeb("https://api.varipass.org/?action=sgraph&id=kbg3eQfA&width=400&height=300&eink=true", 200, 150)) {
+    //If is something failed (wrong filename or wrong bitmap format), write error message on the screen.
+    //REMEMBER! You can only use Windows Bitmap file with color depth of 1 or 24 bits with no compression! 
+    display.println("Image open error");
+    display.partialUpdate();
+  }
+  display.partialUpdate();
+
+  WiFi.mode(WIFI_OFF);
+}
+
+void loop() {
+  //Nothing...
+}


### PR DESCRIPTION
This pull request adds the following features and fixes:
- Adds 4 bit grayscale bitmap support both for SD and Web loading.
- Adds 8 bit grayscale bitmap support both for SD and Web loading.
- Adds invert parameter to SD bitmap loading.
- Adds *3-Inkplate_VariPass_Graphs* example under *3. Others examples*.
- Modifies the *10-Inkplate_Download_And_Show* example to show how to load from Web manually.
- Fixes a 1 pixel vertical offset when drawing bitmaps from SD or Web.